### PR TITLE
Allow selectors in --context

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -75,18 +75,18 @@ parseInput(options, args)
     trees.some(tree => {
       const results = search(tree, pattern, options)
       const cwd = process.cwd()
+      const sourcePath = tree.source.path
+      const relativePath = sourcePath.indexOf(cwd) === 0
+        ? sourcePath.substr(cwd.length)
+        : sourcePath
       if (results.length) {
-        const {source} = tree
-        const relativeSource = source.indexOf(cwd) === 0
-          ? source.substr(cwd.length)
-          : source
-        console.warn('%s:', chalk.green(relativeSource))
+        console.warn('%s:', chalk.green(relativePath))
         done = results.some(result => {
           console.log(result.output)
           if (++count == limit) return true
         })
       } else {
-        // console.warn('%s: 0 results', chalk.yellow(tree.source))
+        // console.warn('%s: 0 results', chalk.yellow(relativePath))
       }
       return done
     })

--- a/cli.js
+++ b/cli.js
@@ -14,10 +14,13 @@ const yargs = require('yargs')
     alias: 's',
   })
   .option('context', {
-    desc: 'How much context to show',
-    default: 0,
-    type: 'number',
+    desc: 'How many parent levels to ascend before showing output, or a selector at which to stop',
     alias: 'c',
+    coerce: value => {
+      return (value && !isNaN(Number(value)))
+        ? Number(value)
+        : value
+    },
   })
   .option('unique', {
     desc: 'Only list unique values',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const addParents = require('unist-util-parents')
 const chalk = require('chalk')
+const is = require('unist-util-is')
 const select = require('unist-util-select')
 const stringifyPosition = require('unist-util-stringify-position')
 const {createFilter, ascending, descending} = require('./src/predicates')
@@ -93,10 +94,23 @@ const search = (tree, selector, options) => {
   return results
 }
 
-const contextualize = (node, depth) => {
-  for (let i = 0; i < depth; i++) {
-    if (!node.parent) break
-    node = node.parent
+const contextualize = (node, selectorOrDepth) => {
+  if (typeof selectorOrDepth === 'number') {
+    const depth = selectorOrDepth
+    for (let i = 0; i < depth; i++) {
+      if (!node.parent) break
+      node = node.parent
+    }
+  } else {
+    const selector = selectorOrDepth
+    let parent = node
+    do {
+      if (is(selector, parent)) {
+        return parent
+      }
+      parent = parent.parent
+    } while (parent)
+    return parent || node
   }
   return node
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chalk": "^2.2.0",
     "epipebomb": "^1.0.0",
     "globby": "^6.1.0",
-    "sast": "^0.3.0",
+    "sast": "^0.5.0",
     "unist-util-is": "^2.1.1",
     "unist-util-parents": "^1.0.0",
     "unist-util-select": "^1.5.0",


### PR DESCRIPTION
This makes it possible to provide a selector in the `--context` option, so that `contextualize()` will look up the parent chain of the selected node until it finds one that `is(context, parent)`, according to [unist-util-is](https://www.npmjs.com/package/unist-util-is). This makes it possible to always see matched nodes in the same context, e.g.

```sh
# always show variables used in the context of a ruleset:
stylegrep variable path/to/file.scss --context ruleset
```